### PR TITLE
vars: fix build on 32bit arches with EFI detection.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,10 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.9
+    - name: Build ARM
+      run: GOARCH=arm go build -v github.com/canonical/go-efilib/...
+    - name: Build ARM64
+      run: GOARCH=arm64 go build -v github.com/canonical/go-efilib/...
     - name: Build
       run: go build -v github.com/canonical/go-efilib/...
     - name: Test
@@ -56,6 +60,10 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Build ARM
+      run: GOARCH=arm go build -v -mod=readonly ./...
+    - name: Build ARM64
+      run: GOARCH=arm64 go build -v -mod=readonly ./...
     - name: Build
       run: go build -v -mod=readonly ./...
     - name: Test


### PR DESCRIPTION
The kernel ABI is a bit broken in such cases. The EFIVARFS_MAGIC
constant overflows `long` size on 32bit platforms. And kernel does not
care. Golang however does, as the contstant is stored as int64 and
fails to downcast with overflow.

Fixes #2

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@canonical.com>