### PR TITLE
vars: Unlink the path when writing an empty payload

### DIFF
--- a/export_linux_test.go
+++ b/export_linux_test.go
@@ -34,6 +34,22 @@ func MockOpenVarFile(fn func(string, int, os.FileMode) (VarFile, error)) (restor
 	}
 }
 
+func MockRemoveVarFile(fn func(string) error) (restore func()) {
+	orig := removeVarFile
+
+	removeVarFile = func(path string) error {
+		err := fn(path)
+		if err == Defer {
+			return orig(path)
+		}
+		return err
+	}
+
+	return func() {
+		removeVarFile = orig
+	}
+}
+
 func MockUnixStatfs(fn func(string, *unix.Statfs_t) error) (restore func()) {
 	orig := unixStatfs
 	unixStatfs = fn

--- a/mockable_linux.go
+++ b/mockable_linux.go
@@ -5,10 +5,13 @@
 package efi
 
 import (
+	"os"
+
 	"golang.org/x/sys/unix"
 )
 
 var (
-	openVarFile = realOpenVarFile
-	unixStatfs  = unix.Statfs
+	openVarFile   = realOpenVarFile
+	removeVarFile = os.Remove
+	unixStatfs    = unix.Statfs
 )


### PR DESCRIPTION
EFI variables are deleted by writing an empty payload to them, which
must be a signed empty payload for authenticated variables. However,
the kernel does some validation of the variable payload when it is
set, and this validation is too strict for Boot* variables (it rejects
an empty payload).

efivarfs will set a variable to an empty payload when a path is unlinked,
so use this when trying to set a variable payload to zero bytes.