### PR TITLE
Replace xerrors

### DIFF
--- a/authvars.go
+++ b/authvars.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/canonical/go-efilib/internal/ioerr"
 	"github.com/canonical/go-efilib/internal/uefi"
-	"golang.org/x/xerrors"
 )
 
 // VariableAuthentication corresponds to the EFI_VARIABLE_AUTHENTICATION
@@ -170,7 +169,7 @@ func ReadEnhancedVariableAuthentication(r io.Reader) (VariableAuthentication3, e
 
 		sig, err := newWinCertificateGUID(signingCert)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot decode signature: %w", err)
+			return nil, fmt.Errorf("cannot decode signature: %w", err)
 		}
 
 		out := &VariableAuthentication3Timestamp{
@@ -179,7 +178,7 @@ func ReadEnhancedVariableAuthentication(r io.Reader) (VariableAuthentication3, e
 		if newCert != nil {
 			sig, err := newWinCertificateGUID(newCert)
 			if err != nil {
-				return nil, xerrors.Errorf("cannot decode new authority signature: %w", err)
+				return nil, fmt.Errorf("cannot decode new authority signature: %w", err)
 			}
 			out.newCert = sig
 		}
@@ -206,7 +205,7 @@ func ReadEnhancedVariableAuthentication(r io.Reader) (VariableAuthentication3, e
 
 		sig, err := newWinCertificateGUID(signingCert)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot decode signature: %w", err)
+			return nil, fmt.Errorf("cannot decode signature: %w", err)
 		}
 
 		out := &VariableAuthentication3Nonce{
@@ -215,7 +214,7 @@ func ReadEnhancedVariableAuthentication(r io.Reader) (VariableAuthentication3, e
 		if newCert != nil {
 			sig, err := newWinCertificateGUID(newCert)
 			if err != nil {
-				return nil, xerrors.Errorf("cannot decode new authority signature: %w", err)
+				return nil, fmt.Errorf("cannot decode new authority signature: %w", err)
 			}
 			out.newCert = sig
 		}
@@ -331,7 +330,7 @@ func ReadEnhancedAuthenticationDescriptor(r io.Reader) (VariableAuthentication3D
 
 		id2, err := newVariableAuthentication3CertId(id)
 		if err != nil {
-			return nil, xerrors.Errorf("invalid timestamp descriptor ID: %w", err)
+			return nil, fmt.Errorf("invalid timestamp descriptor ID: %w", err)
 		}
 
 		return &VariableAuthentication3TimestampDescriptor{
@@ -350,7 +349,7 @@ func ReadEnhancedAuthenticationDescriptor(r io.Reader) (VariableAuthentication3D
 
 		id2, err := newVariableAuthentication3CertId(id)
 		if err != nil {
-			return nil, xerrors.Errorf("invalid nonce descriptor ID: %w", err)
+			return nil, fmt.Errorf("invalid nonce descriptor ID: %w", err)
 		}
 
 		return &VariableAuthentication3NonceDescriptor{

--- a/db.go
+++ b/db.go
@@ -13,8 +13,6 @@ import (
 	"io"
 
 	"github.com/canonical/go-efilib/internal/uefi"
-
-	"golang.org/x/xerrors"
 )
 
 // SignatureData corresponds to the EFI_SIGNATURE_DATA type.
@@ -149,7 +147,7 @@ func (db SignatureDatabase) Bytes() ([]byte, error) {
 func (db SignatureDatabase) Write(w io.Writer) error {
 	for i, l := range db {
 		if err := l.Write(w); err != nil {
-			return xerrors.Errorf("cannot encode signature list %d: %w", i, err)
+			return fmt.Errorf("cannot encode signature list %d: %w", i, err)
 		}
 	}
 	return nil
@@ -164,7 +162,7 @@ func ReadSignatureDatabase(r io.Reader) (SignatureDatabase, error) {
 			if err == io.EOF {
 				break
 			}
-			return nil, xerrors.Errorf("cannot read EFI_SIGNATURE_LIST %d: %w", i, err)
+			return nil, fmt.Errorf("cannot read EFI_SIGNATURE_LIST %d: %w", i, err)
 		}
 		db = append(db, l)
 	}

--- a/devicepath.go
+++ b/devicepath.go
@@ -19,8 +19,6 @@ import (
 	"github.com/canonical/go-efilib/internal/ioerr"
 	"github.com/canonical/go-efilib/internal/uefi"
 	"github.com/canonical/go-efilib/mbr"
-
-	"golang.org/x/xerrors"
 )
 
 // DevicePathType is the type of a device path node.
@@ -1107,7 +1105,7 @@ func decodeDevicePathNode(r io.Reader) (out DevicePathNode, err error) {
 		switch {
 		case err == io.EOF:
 			fallthrough
-		case xerrors.Is(err, io.ErrUnexpectedEOF):
+		case errors.Is(err, io.ErrUnexpectedEOF):
 			err = fmt.Errorf("invalid length %d bytes (too small)", h.Length)
 		case err != nil:
 		case buf.Len() > 0:

--- a/devicepath.go
+++ b/devicepath.go
@@ -106,7 +106,7 @@ func (p DevicePath) Bytes() ([]byte, error) {
 func (p DevicePath) Write(w io.Writer) error {
 	for i, node := range p {
 		if err := node.Write(w); err != nil {
-			return xerrors.Errorf("cannot write node %d: %w", i, err)
+			return fmt.Errorf("cannot write node %d: %w", i, err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	golang.org/x/crypto v0.9.0
 	golang.org/x/sys v0.8.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,5 @@ golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/gpt.go
+++ b/gpt.go
@@ -12,8 +12,6 @@ import (
 	"hash/crc32"
 	"io"
 
-	"golang.org/x/xerrors"
-
 	"github.com/canonical/go-efilib/internal/uefi"
 	"github.com/canonical/go-efilib/mbr"
 )
@@ -200,7 +198,7 @@ func readPartitionEntries(r io.Reader, num, sz, expectedCrc uint32, checkCrc boo
 			case err == io.EOF:
 				err = io.ErrUnexpectedEOF
 			}
-			return nil, xerrors.Errorf("cannot read entry %d: %w", i, err)
+			return nil, fmt.Errorf("cannot read entry %d: %w", i, err)
 		}
 
 		e, err := ReadPartitionEntry(b)

--- a/internal/ioerr/ioerr.go
+++ b/internal/ioerr/ioerr.go
@@ -5,12 +5,11 @@
 package ioerr
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"unicode"
 	"unicode/utf8"
-
-	"golang.org/x/xerrors"
 )
 
 // Return the index of the first %w in format, or -1 if none.
@@ -97,7 +96,7 @@ func EOFIsUnexpected(args ...interface{}) error {
 // io.EOF if this is the error.
 func PassRawEOF(format string, args ...interface{}) error {
 	err := fmt.Errorf(format, args...)
-	if xerrors.Is(err, io.EOF) {
+	if errors.Is(err, io.EOF) {
 		return io.EOF
 	}
 	return err

--- a/internal/ioerr/ioerr.go
+++ b/internal/ioerr/ioerr.go
@@ -5,6 +5,7 @@
 package ioerr
 
 import (
+	"fmt"
 	"io"
 	"unicode"
 	"unicode/utf8"
@@ -60,7 +61,7 @@ func parsePrintfVerb(s string) (int, bool) {
 // It can be called in one of 2 ways - either with a single argument which
 // must be an error, or with a format string and an arbitrary number of
 // arguments. In this second mode, the function is a wrapper around
-// xerrors.Errorf.
+// fmt.Errorf.
 //
 // This only works on raw io.EOF errors - ie, it won't work on errors that
 // have been wrapped.
@@ -74,7 +75,7 @@ func EOFIsUnexpected(args ...interface{}) error {
 				args[idx+1] = io.ErrUnexpectedEOF
 			}
 		}
-		return xerrors.Errorf(format, args[1:]...)
+		return fmt.Errorf(format, args[1:]...)
 	case len(args) == 1:
 		switch err := args[0].(type) {
 		case error:
@@ -92,10 +93,10 @@ func EOFIsUnexpected(args ...interface{}) error {
 	}
 }
 
-// PassRawEOF is a wrapper around xerrors.Errorf that will return a raw
+// PassRawEOF is a wrapper around fmt.Errorf that will return a raw
 // io.EOF if this is the error.
 func PassRawEOF(format string, args ...interface{}) error {
-	err := xerrors.Errorf(format, args...)
+	err := fmt.Errorf(format, args...)
 	if xerrors.Is(err, io.EOF) {
 		return io.EOF
 	}

--- a/internal/ioerr/ioerr_test.go
+++ b/internal/ioerr/ioerr_test.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"testing"
 
-	"golang.org/x/xerrors"
-
 	. "gopkg.in/check.v1"
 
 	. "github.com/canonical/go-efilib/internal/ioerr"
@@ -25,27 +23,27 @@ var _ = Suite(&ioerrSuite{})
 func (s *ioerrSuite) TestEOFIsUnexpectedWithEOFAndWithFormatString(c *C) {
 	err := EOFIsUnexpected("foo: %w", io.EOF)
 	c.Check(err, ErrorMatches, "foo: unexpected EOF")
-	c.Check(xerrors.Is(err, io.ErrUnexpectedEOF), Equals, true)
+	c.Check(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
 }
 
 func (s *ioerrSuite) TestEOFIsUnexpectedWithoutEOFAndWithFormatString(c *C) {
 	err1 := errors.New("bar")
 	err2 := EOFIsUnexpected("foo: %w", err1)
 	c.Check(err2, ErrorMatches, "foo: bar")
-	c.Check(xerrors.Is(err2, err1), Equals, true)
+	c.Check(errors.Is(err2, err1), Equals, true)
 }
 
 func (s *ioerrSuite) TestEOFIsUnexpectedWithEOFAndWithFormatString2(c *C) {
 	err := EOFIsUnexpected("foo %w %d", io.EOF, 5)
 	c.Check(err, ErrorMatches, "foo unexpected EOF 5: unexpected EOF")
-	c.Check(xerrors.Is(err, io.ErrUnexpectedEOF), Equals, true)
+	c.Check(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
 }
 
 func (s *ioerrSuite) TestEOFIsUnexpectedWithoutEOFAndWithFormatString2(c *C) {
 	err1 := errors.New("bar")
 	err2 := EOFIsUnexpected("foo %w %d", err1, 5)
 	c.Check(err2, ErrorMatches, "foo bar 5: bar")
-	c.Check(xerrors.Is(err2, err1), Equals, true)
+	c.Check(errors.Is(err2, err1), Equals, true)
 }
 
 func (s *ioerrSuite) TestEOFIsUnexpectedWithEOF(c *C) {
@@ -69,5 +67,5 @@ func (s *ioerrSuite) TestPassRawEOFWithoutEOF(c *C) {
 	err1 := errors.New("bar")
 	err2 := PassRawEOF("foo: %w", err1)
 	c.Check(err2, ErrorMatches, "foo: bar")
-	c.Check(xerrors.Is(err2, err1), Equals, true)
+	c.Check(errors.Is(err2, err1), Equals, true)
 }

--- a/internal/ioerr/ioerr_test.go
+++ b/internal/ioerr/ioerr_test.go
@@ -35,14 +35,14 @@ func (s *ioerrSuite) TestEOFIsUnexpectedWithoutEOFAndWithFormatString(c *C) {
 
 func (s *ioerrSuite) TestEOFIsUnexpectedWithEOFAndWithFormatString2(c *C) {
 	err := EOFIsUnexpected("foo %w %d", io.EOF, 5)
-	c.Check(err, ErrorMatches, "foo unexpected EOF 5: unexpected EOF")
+	c.Check(err, ErrorMatches, "foo unexpected EOF 5")
 	c.Check(errors.Is(err, io.ErrUnexpectedEOF), Equals, true)
 }
 
 func (s *ioerrSuite) TestEOFIsUnexpectedWithoutEOFAndWithFormatString2(c *C) {
 	err1 := errors.New("bar")
 	err2 := EOFIsUnexpected("foo %w %d", err1, 5)
-	c.Check(err2, ErrorMatches, "foo bar 5: bar")
+	c.Check(err2, ErrorMatches, "foo bar 5")
 	c.Check(errors.Is(err2, err1), Equals, true)
 }
 

--- a/linux/disk.go
+++ b/linux/disk.go
@@ -6,12 +6,12 @@ package linux
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"os"
 	"syscall"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/xerrors"
 
 	efi "github.com/canonical/go-efilib"
 	internal_unix "github.com/canonical/go-efilib/internal/unix"
@@ -83,12 +83,12 @@ func NewHardDriveDevicePathNodeFromDevice(dev string, part int) (*efi.HardDriveD
 
 	sz, err := getDeviceSize(f)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot determine device size: %w", err)
+		return nil, fmt.Errorf("cannot determine device size: %w", err)
 	}
 
 	ssz, err := getSectorSize(f)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot determine logical sector size: %w", err)
+		return nil, fmt.Errorf("cannot determine logical sector size: %w", err)
 	}
 
 	return efi.NewHardDriveDevicePathNodeFromDevice(f, sz, ssz, part)

--- a/linux/dp_ata.go
+++ b/linux/dp_ata.go
@@ -12,8 +12,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"golang.org/x/xerrors"
 )
 
 // ataRE matches an ATA path component, capturing the ATA print ID.
@@ -44,18 +42,18 @@ func handleATAPath(path string) (*ataParams, error) {
 
 	printId, err := strconv.ParseUint(m[1], 10, 32)
 	if err != nil {
-		return nil, xerrors.Errorf("invalid print ID: %w", err)
+		return nil, fmt.Errorf("invalid print ID: %w", err)
 	}
 
 	// Obtain the ATA port number local to this ATA controller. The kernel
 	// creates one ata%d device per port (see drivers/ata/libata-core.c:ata_host_register).
 	portBytes, err := os.ReadFile(filepath.Join(path, "../../../../..", "ata_port", ata, "port_no"))
 	if err != nil {
-		return nil, xerrors.Errorf("cannot obtain port ID: %w", err)
+		return nil, fmt.Errorf("cannot obtain port ID: %w", err)
 	}
 	port, err := strconv.ParseUint(strings.TrimSpace(string(portBytes)), 10, 16)
 	if err != nil {
-		return nil, xerrors.Errorf("invalid port ID: %w", err)
+		return nil, fmt.Errorf("invalid port ID: %w", err)
 	}
 
 	return &ataParams{

--- a/linux/dp_nvme.go
+++ b/linux/dp_nvme.go
@@ -13,8 +13,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"golang.org/x/xerrors"
-
 	efi "github.com/canonical/go-efilib"
 )
 
@@ -36,7 +34,7 @@ func handleNVMEDevicePathNode(state *devicePathBuilderState) error {
 
 	nsid, err := strconv.ParseUint(m[1], 10, 32)
 	if err != nil {
-		return xerrors.Errorf("cannot parse nsid: %w", err)
+		return fmt.Errorf("cannot parse nsid: %w", err)
 	}
 
 	var euid [8]uint8
@@ -49,12 +47,12 @@ func handleNVMEDevicePathNode(state *devicePathBuilderState) error {
 	case os.IsNotExist(err):
 		// Nothing to do
 	case err != nil:
-		return xerrors.Errorf("cannot determine euid: %w", err)
+		return fmt.Errorf("cannot determine euid: %w", err)
 	default:
 		n, err := fmt.Sscanf(string(euidBuf), "%02x %02x %02x %02x %02x %02x %02x %02x",
 			&euid[0], &euid[1], &euid[2], &euid[3], &euid[4], &euid[5], &euid[6], &euid[7])
 		if err != nil {
-			return xerrors.Errorf("cannot parse euid: %w", err)
+			return fmt.Errorf("cannot parse euid: %w", err)
 		}
 		if n != 8 {
 			return errors.New("invalid euid")

--- a/linux/dp_pci.go
+++ b/linux/dp_pci.go
@@ -13,8 +13,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"golang.org/x/xerrors"
-
 	efi "github.com/canonical/go-efilib"
 )
 
@@ -40,7 +38,7 @@ func handlePCIDevicePathNode(state *devicePathBuilderState) error {
 
 	classBytes, err := os.ReadFile(filepath.Join(state.SysfsPath(), "class"))
 	if err != nil {
-		return xerrors.Errorf("cannot read device class: %w", err)
+		return fmt.Errorf("cannot read device class: %w", err)
 	}
 
 	var class []byte

--- a/linux/dp_scsi.go
+++ b/linux/dp_scsi.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 
 	efi "github.com/canonical/go-efilib"
-
-	"golang.org/x/xerrors"
 )
 
 // scsiRE matches a SCSI path, capturing the channel, target and LUN.
@@ -42,15 +40,15 @@ func handleSCSIPath(path string) (*scsiParams, error) {
 
 	channel, err := strconv.ParseUint(m[1], 10, 32)
 	if err != nil {
-		return nil, xerrors.Errorf("invalid channel: %w", err)
+		return nil, fmt.Errorf("invalid channel: %w", err)
 	}
 	target, err := strconv.ParseUint(m[2], 10, 32)
 	if err != nil {
-		return nil, xerrors.Errorf("invalid target: %w", err)
+		return nil, fmt.Errorf("invalid target: %w", err)
 	}
 	lun, err := strconv.ParseUint(m[3], 10, 64)
 	if err != nil {
-		return nil, xerrors.Errorf("invalid lun: %w", err)
+		return nil, fmt.Errorf("invalid lun: %w", err)
 	}
 
 	return &scsiParams{

--- a/linux/filepath.go
+++ b/linux/filepath.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/xerrors"
 
 	efi "github.com/canonical/go-efilib"
 )
@@ -344,11 +343,11 @@ func newFilePath(path string) (*filePath, error) {
 		out.dev.devPath = filepath.Join("/dev", filepath.Base(parentDev))
 		b, err := os.ReadFile(filepath.Join(childDev, "partition"))
 		if err != nil {
-			return nil, xerrors.Errorf("cannot obtain partition number for %s: %w", mount.dev, err)
+			return nil, fmt.Errorf("cannot obtain partition number for %d: %w", mount.dev, err)
 		}
 		part, err := strconv.Atoi(strings.TrimSpace(string(b)))
 		if err != nil {
-			return nil, xerrors.Errorf("cannot determine partition number for %s: %w", mount.dev, err)
+			return nil, fmt.Errorf("cannot determine partition number for %d: %w", mount.dev, err)
 		}
 		out.dev.part = part
 	}

--- a/linux/filepath.go
+++ b/linux/filepath.go
@@ -173,7 +173,7 @@ func (b *devicePathBuilder) ProcessNextComponent() error {
 			continue
 		}
 		if err != nil {
-			return xerrors.Errorf("[handler %s]: %w", handler.name, err)
+			return fmt.Errorf("[handler %s]: %w", handler.name, err)
 		}
 
 		if iface != interfaceTypeUnknown && b.Interface == interfaceTypeUnknown {
@@ -233,11 +233,11 @@ func scanBlockDeviceMounts() (mounts []*mountPoint, err error) {
 		}
 		devMajor, err := strconv.ParseUint(devStr[0], 10, 32)
 		if err != nil {
-			return nil, xerrors.Errorf("invalid mount info: invalid device number: %w", err)
+			return nil, fmt.Errorf("invalid mount info: invalid device number: %w", err)
 		}
 		devMinor, err := strconv.ParseUint(devStr[1], 10, 32)
 		if err != nil {
-			return nil, xerrors.Errorf("invalid mount info: invalid device number: %w", err)
+			return nil, fmt.Errorf("invalid mount info: invalid device number: %w", err)
 		}
 
 		var mountSource string
@@ -257,7 +257,7 @@ func scanBlockDeviceMounts() (mounts []*mountPoint, err error) {
 			mountSource: mountSource})
 	}
 	if scanner.Err() != nil {
-		return nil, xerrors.Errorf("cannot parse mount info: %w", err)
+		return nil, fmt.Errorf("cannot parse mount info: %w", err)
 	}
 
 	return mounts, nil
@@ -266,7 +266,7 @@ func scanBlockDeviceMounts() (mounts []*mountPoint, err error) {
 func getFileMountPoint(path string) (*mountPoint, error) {
 	mounts, err := scanBlockDeviceMounts()
 	if err != nil {
-		return nil, xerrors.Errorf("cannot obtain list of block device mounts: %w", err)
+		return nil, fmt.Errorf("cannot obtain list of block device mounts: %w", err)
 	}
 
 	var candidate *mountPoint
@@ -305,12 +305,12 @@ type filePath struct {
 func newFilePath(path string) (*filePath, error) {
 	path, err := filepathEvalSymlinks(path)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot evaluate symbolic links: %w", err)
+		return nil, fmt.Errorf("cannot evaluate symbolic links: %w", err)
 	}
 
 	mount, err := getFileMountPoint(path)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot obtain mount information for path: %w", err)
+		return nil, fmt.Errorf("cannot obtain mount information for path: %w", err)
 	}
 
 	rel, err := filepath.Rel(mount.mountDir, path)
@@ -404,7 +404,7 @@ func FilePathToDevicePath(path string, mode FilePathToDevicePathMode) (out efi.D
 					builder.PeekUnhandledSysfsComponents(-1) + " from device path " +
 					builder.SysfsPath() + ": " + err.Error())
 			case err != nil:
-				return nil, xerrors.Errorf("cannot process components %s from device path %s: %w",
+				return nil, fmt.Errorf("cannot process components %s from device path %s: %w",
 					builder.PeekUnhandledSysfsComponents(-1), builder.SysfsPath(), err)
 			}
 		}
@@ -415,7 +415,7 @@ func FilePathToDevicePath(path string, mode FilePathToDevicePathMode) (out efi.D
 	if mode != ShortFormPathFile && fp.part > 0 {
 		node, err := NewHardDriveDevicePathNodeFromDevice(fp.devPath, fp.part)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot construct hard drive device path node: %w", err)
+			return nil, fmt.Errorf("cannot construct hard drive device path node: %w", err)
 		}
 		out = append(out, node)
 	}

--- a/linux/filepath.go
+++ b/linux/filepath.go
@@ -399,7 +399,7 @@ func FilePathToDevicePath(path string, mode FilePathToDevicePathMode) (out efi.D
 
 			err := builder.ProcessNextComponent()
 			switch {
-			case xerrors.As(err, &e):
+			case errors.As(err, &e):
 				return nil, ErrNoDevicePath("encountered an error when handling components " +
 					builder.PeekUnhandledSysfsComponents(-1) + " from device path " +
 					builder.SysfsPath() + ": " + err.Error())

--- a/linux/gpt.go
+++ b/linux/gpt.go
@@ -5,9 +5,8 @@
 package linux
 
 import (
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	efi "github.com/canonical/go-efilib"
 )
@@ -41,12 +40,12 @@ func ReadPartitionTable(path string, role efi.PartitionTableRole, checkCrc bool)
 
 	sz, err := getDeviceSize(f)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot determine device size: %w", err)
+		return nil, fmt.Errorf("cannot determine device size: %w", err)
 	}
 
 	ssz, err := getSectorSize(f)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot determine logical sector size: %w", err)
+		return nil, fmt.Errorf("cannot determine logical sector size: %w", err)
 	}
 
 	return efi.ReadPartitionTable(f, sz, ssz, role, checkCrc)

--- a/loadoption.go
+++ b/loadoption.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"math"
 
-	"golang.org/x/xerrors"
-
 	"github.com/canonical/go-efilib/internal/uefi"
 )
 
@@ -89,7 +87,7 @@ func ReadLoadOption(r io.Reader) (out *LoadOption, err error) {
 
 	dp, err := ReadDevicePath(bytes.NewReader(opt.FilePathList))
 	if err != nil {
-		return nil, xerrors.Errorf("cannot read device path: %w", err)
+		return nil, fmt.Errorf("cannot read device path: %w", err)
 	}
 	out.FilePath = dp
 

--- a/vars_linux.go
+++ b/vars_linux.go
@@ -7,6 +7,7 @@ package efi
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"syscall"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/xerrors"
 
 	internal_unix "github.com/canonical/go-efilib/internal/unix"
 )
@@ -110,7 +110,7 @@ func maybeRetry(n int, fn func() (bool, error)) error {
 func processEfivarfsFileAccessError(err error) (retry bool, errOut error) {
 	if os.IsPermission(err) {
 		var se syscall.Errno
-		if !xerrors.As(err, &se) {
+		if !errors.As(err, &se) {
 			// This shouldn't happen, but just return ErrVarPermission
 			// in this case and don't retry.
 			return false, ErrVarPermission

--- a/wincert.go
+++ b/wincert.go
@@ -17,7 +17,6 @@ import (
 
 	"golang.org/x/crypto/cryptobyte"
 	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/xerrors"
 
 	"github.com/canonical/go-efilib/internal/ioerr"
 	"github.com/canonical/go-efilib/internal/pkcs7"
@@ -367,7 +366,7 @@ func newWinCertificateGUID(cert *uefi.WIN_CERTIFICATE_UEFI_GUID) (WinCertificate
 	case uefi.EFI_CERT_TYPE_PKCS7_GUID:
 		p7, err := pkcs7.UnmarshalSignedData(cert.CertData)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot decode payload for WIN_CERTIFICATE_UEFI_GUID with EFI_CERT_TYPE_PKCS7_GUID type: %w", err)
+			return nil, fmt.Errorf("cannot decode payload for WIN_CERTIFICATE_UEFI_GUID with EFI_CERT_TYPE_PKCS7_GUID type: %w", err)
 		}
 		return &WinCertificatePKCS7{p7: p7}, nil
 	default:
@@ -540,7 +539,7 @@ func ReadWinCertificate(r io.Reader) (WinCertificate, error) {
 
 		p7, err := pkcs7.UnmarshalSignedData(cert.CertData)
 		if err != nil {
-			return nil, xerrors.Errorf("cannot decode WIN_CERTIFICATE_EFI_PKCS payload: %w", err)
+			return nil, fmt.Errorf("cannot decode WIN_CERTIFICATE_EFI_PKCS payload: %w", err)
 		}
 		if len(p7.GetSigners()) != 1 {
 			return nil, errors.New("WIN_CERTIFICATE_EFI_PKCS has invalid number of signers")
@@ -551,7 +550,7 @@ func ReadWinCertificate(r io.Reader) (WinCertificate, error) {
 		}
 		auth, err := unmarshalAuthenticodeContent(p7.Content())
 		if err != nil {
-			return nil, xerrors.Errorf("cannot decode authenticode content for WIN_CERTIFICATE_EFI_PKCS: %w", err)
+			return nil, fmt.Errorf("cannot decode authenticode content for WIN_CERTIFICATE_EFI_PKCS: %w", err)
 		}
 		return &WinCertificateAuthenticode{p7: p7, authenticode: auth}, nil
 	case uefi.WIN_CERT_TYPE_EFI_PKCS115:
@@ -569,7 +568,7 @@ func ReadWinCertificate(r io.Reader) (WinCertificate, error) {
 
 		digest, err := digestAlgorithmIdToCryptoHash(GUID(cert.HashAlgorithm))
 		if err != nil {
-			return nil, xerrors.Errorf("cannot determine digest algorithm for WIN_CERTIFICATE_EFI_PKCS1_15: %w", err)
+			return nil, fmt.Errorf("cannot determine digest algorithm for WIN_CERTIFICATE_EFI_PKCS1_15: %w", err)
 		}
 
 		return &WinCertificatePKCS1v15{HashAlgorithm: digest, Signature: cert.Signature}, nil


### PR DESCRIPTION
As of Go 1.13, Errorf's %w verb has been incorporated into fmt.Errorf and the As and Is functions have been incorporated into the standard library's errors package.

https://pkg.go.dev/golang.org/x/xerrors#pkg-overview