### PR TITLE
Use alternatives to deprecated ioutil package

### DIFF
--- a/cmd/efi_devicepath/main.go
+++ b/cmd/efi_devicepath/main.go
@@ -7,12 +7,12 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 
-	"github.com/canonical/go-efilib"
-	"github.com/canonical/go-efilib/linux"
 	"github.com/jessevdk/go-flags"
+
+	efi "github.com/canonical/go-efilib"
+	"github.com/canonical/go-efilib/linux"
 )
 
 type mode linux.FilePathToDevicePathMode
@@ -96,7 +96,7 @@ func run() error {
 			return fmt.Errorf("cannot serialize path: %v", err)
 		}
 
-		if err := ioutil.WriteFile(opts.Output, b, 0644); err != nil {
+		if err := os.WriteFile(opts.Output, b, 0644); err != nil {
 			return err
 		}
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	. "github.com/canonical/go-efilib"
@@ -422,7 +421,7 @@ func (s *dbSuite) TestWriteSignatureData(c *C) {
 	c.Check(err, IsNil)
 	c.Check(owner, Equals, d.Owner)
 
-	data, err := ioutil.ReadAll(&b)
+	data, err := io.ReadAll(&b)
 	c.Check(err, IsNil)
 	c.Check(data, DeepEquals, d.Data)
 }

--- a/devicepath.go
+++ b/devicepath.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -263,7 +262,7 @@ func readVendorDevicePathNode(r io.Reader) (out *VendorDevicePathNode, err error
 	out = &VendorDevicePathNode{
 		Type: DevicePathType(n.Header.Type),
 		GUID: GUID(n.Guid)}
-	data, _ := ioutil.ReadAll(r)
+	data, _ := io.ReadAll(r)
 	out.Data = data
 
 	return out, nil
@@ -1292,7 +1291,7 @@ func decodeDevicePathNode(r io.Reader) (out DevicePathNode, err error) {
 	if err := binary.Read(buf, binary.LittleEndian, &n); err != nil {
 		return nil, err
 	}
-	data, _ := ioutil.ReadAll(buf)
+	data, _ := io.ReadAll(buf)
 	return &GenericDevicePathNode{Type: DevicePathType(n.Type), SubType: DevicePathSubType(n.SubType), Data: data}, nil
 }
 

--- a/efi_test.go
+++ b/efi_test.go
@@ -6,7 +6,7 @@ package efi
 
 import (
 	"encoding/hex"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -21,7 +21,7 @@ func DecodeHexString(c *C, s string) []byte {
 }
 
 func ReadFile(c *C, path string) []byte {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	c.Assert(err, IsNil)
 	return data
 }

--- a/internal/pkcs7/pkcs7_test.go
+++ b/internal/pkcs7/pkcs7_test.go
@@ -6,7 +6,7 @@ package pkcs7_test
 
 import (
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -26,7 +26,7 @@ func (s *pkcs7Suite) TestUnmarshalSignedDataUnwrapped(c *C) {
 	c.Assert(err, IsNil)
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	c.Check(err, IsNil)
 
 	p, err := UnmarshalSignedData(b)
@@ -40,7 +40,7 @@ func (s *pkcs7Suite) TestUnmarshalSignedDataWrapped(c *C) {
 	c.Assert(err, IsNil)
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	c.Check(err, IsNil)
 
 	p, err := UnmarshalSignedData(b)
@@ -55,7 +55,7 @@ func (s *pkcs7Suite) TestUnmarshalSignedDAtaWithTrailingBytes(c *C) {
 	c.Assert(err, IsNil)
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	c.Check(err, IsNil)
 
 	p, err := UnmarshalSignedData(b)

--- a/internal/uefi/loadoption.go
+++ b/internal/uefi/loadoption.go
@@ -7,7 +7,6 @@ package uefi
 import (
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 
 	"github.com/canonical/go-efilib/internal/ioerr"
 )
@@ -72,7 +71,7 @@ func Read_EFI_LOAD_OPTION(r io.Reader) (out *EFI_LOAD_OPTION, err error) {
 		return nil, ioerr.EOFIsUnexpected(err)
 	}
 
-	optionalData, err := ioutil.ReadAll(r)
+	optionalData, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/linux/dp_acpi.go
+++ b/linux/dp_acpi.go
@@ -9,14 +9,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 )
 
 // acpiIdRE matches a ACPI or PNP ID, capturing the vendor and product.
@@ -56,7 +55,7 @@ func decodeACPIOrPNPId(str string) (efi.EISAID, string) {
 func newACPIExtendedDevicePathNode(path string) (*efi.ACPIExtendedDevicePathNode, error) {
 	node := new(efi.ACPIExtendedDevicePathNode)
 
-	hidBytes, err := ioutil.ReadFile(filepath.Join(path, "hid"))
+	hidBytes, err := os.ReadFile(filepath.Join(path, "hid"))
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +64,7 @@ func newACPIExtendedDevicePathNode(path string) (*efi.ACPIExtendedDevicePathNode
 	node.HID = hid
 	node.HIDStr = hidStr
 
-	modalias, err := ioutil.ReadFile(filepath.Join(path, "modalias"))
+	modalias, err := os.ReadFile(filepath.Join(path, "modalias"))
 	switch {
 	case os.IsNotExist(err):
 	case err != nil:
@@ -82,7 +81,7 @@ func newACPIExtendedDevicePathNode(path string) (*efi.ACPIExtendedDevicePathNode
 		}
 	}
 
-	uidBytes, err := ioutil.ReadFile(filepath.Join(path, "uid"))
+	uidBytes, err := os.ReadFile(filepath.Join(path, "uid"))
 	switch {
 	case os.IsNotExist(err):
 	case err != nil:

--- a/linux/dp_ata.go
+++ b/linux/dp_ata.go
@@ -7,7 +7,6 @@ package linux
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -50,7 +49,7 @@ func handleATAPath(path string) (*ataParams, error) {
 
 	// Obtain the ATA port number local to this ATA controller. The kernel
 	// creates one ata%d device per port (see drivers/ata/libata-core.c:ata_host_register).
-	portBytes, err := ioutil.ReadFile(filepath.Join(path, "../../../../..", "ata_port", ata, "port_no"))
+	portBytes, err := os.ReadFile(filepath.Join(path, "../../../../..", "ata_port", ata, "port_no"))
 	if err != nil {
 		return nil, xerrors.Errorf("cannot obtain port ID: %w", err)
 	}

--- a/linux/dp_hv.go
+++ b/linux/dp_hv.go
@@ -5,10 +5,10 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 )
 
 var (
@@ -25,7 +25,7 @@ func handleHVDevicePathNode(builder devicePathBuilder) error {
 		return err
 	}
 
-	classIdStr, err := ioutil.ReadFile(filepath.Join(builder.absPath(component), "class_id"))
+	classIdStr, err := os.ReadFile(filepath.Join(builder.absPath(component), "class_id"))
 	if err != nil {
 		return err
 	}

--- a/linux/dp_nvme.go
+++ b/linux/dp_nvme.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -16,7 +15,7 @@ import (
 
 	"golang.org/x/xerrors"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 )
 
 // nvmeNSRe matches "nvme/nvme<ctrl_id>/nvme<ctrl_id>n<ns_id>", capturing ns_id
@@ -42,9 +41,9 @@ func handleNVMEDevicePathNode(builder devicePathBuilder) error {
 
 	var euid [8]uint8
 
-	euidBuf, err := ioutil.ReadFile(filepath.Join(builder.absPath(components), "eui"))
+	euidBuf, err := os.ReadFile(filepath.Join(builder.absPath(components), "eui"))
 	if os.IsNotExist(err) {
-		euidBuf, err = ioutil.ReadFile(filepath.Join(builder.absPath(components), "device", "eui"))
+		euidBuf, err = os.ReadFile(filepath.Join(builder.absPath(components), "device", "eui"))
 	}
 	switch {
 	case os.IsNotExist(err):

--- a/linux/dp_pci.go
+++ b/linux/dp_pci.go
@@ -8,14 +8,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 
 	"golang.org/x/xerrors"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 )
 
 var classRE = regexp.MustCompile(`^0x([[:xdigit:]]+)$`)
@@ -36,7 +36,7 @@ func handlePCIDevicePathNode(builder devicePathBuilder) error {
 	devNum, _ := strconv.ParseUint(m[1], 16, 8)
 	fun, _ := strconv.ParseUint(m[2], 10, 8)
 
-	classBytes, err := ioutil.ReadFile(filepath.Join(builder.absPath(component), "class"))
+	classBytes, err := os.ReadFile(filepath.Join(builder.absPath(component), "class"))
 	if err != nil {
 		return xerrors.Errorf("cannot read device class: %w", err)
 	}

--- a/linux/filepath.go
+++ b/linux/filepath.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,7 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 
-	"github.com/canonical/go-efilib"
+	efi "github.com/canonical/go-efilib"
 )
 
 // FilePathToDevicePathMode specifies the mode for FilePathToDevicePath
@@ -366,7 +365,7 @@ func newFilePath(path string) (*filePath, error) {
 		// device.
 		out.dev.sysfsPath = parentDev
 		out.dev.devPath = filepath.Join("/dev", filepath.Base(parentDev))
-		b, err := ioutil.ReadFile(filepath.Join(childDev, "partition"))
+		b, err := os.ReadFile(filepath.Join(childDev, "partition"))
 		if err != nil {
 			return nil, xerrors.Errorf("cannot obtain partition number for %s: %w", mount.dev, err)
 		}

--- a/vars_linux.go
+++ b/vars_linux.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -210,7 +209,7 @@ func (v efivarfsVarsBackend) Get(name string, guid GUID) (VariableAttributes, []
 		return 0, nil, err
 	}
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/wincert_test.go
+++ b/wincert_test.go
@@ -7,7 +7,6 @@ package efi_test
 import (
 	"crypto"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -41,14 +40,14 @@ func (s *wincertSuite) TestReadWinCertificateGUID(c *C) {
 	h.Write(signers[0].RawTBSCertificate)
 	c.Check(h.Sum(nil), DeepEquals, DecodeHexString(c, "607af875b99b8711204eede2c04bdf58d8f65adad8f3013a341503ca878175ea"))
 
-	caBytes, err := ioutil.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
+	caBytes, err := os.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
 	c.Check(err, IsNil)
 	ca, err := x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
 
 	c.Check(p7cert.CertLikelyTrustAnchor(ca), Equals, true)
 
-	caBytes, err = ioutil.ReadFile("testdata/certs/canonical-uefi-ca.der")
+	caBytes, err = os.ReadFile("testdata/certs/canonical-uefi-ca.der")
 	c.Check(err, IsNil)
 	ca, err = x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
@@ -70,14 +69,14 @@ func (s *wincertSuite) TestReadWinCertificateAuthenticode(c *C) {
 	h.Write(authenticodeCert.GetSigner().RawTBSCertificate)
 	c.Check(h.Sum(nil), DeepEquals, DecodeHexString(c, "08954ce3da028da0128a81435159f543d70ccd789ee86ea55630dab9a765644e"))
 
-	caBytes, err := ioutil.ReadFile("testdata/certs/canonical-uefi-ca.der")
+	caBytes, err := os.ReadFile("testdata/certs/canonical-uefi-ca.der")
 	c.Check(err, IsNil)
 	ca, err := x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
 
 	c.Check(authenticodeCert.CertLikelyTrustAnchor(ca), Equals, true)
 
-	caBytes, err = ioutil.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
+	caBytes, err = os.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
 	c.Check(err, IsNil)
 	ca, err = x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
@@ -98,7 +97,7 @@ func (s *wincertSuite) TestWinCertificationAuthenticodeCertLikelyTrustAnchorWith
 	authenticodeCert, ok := cert.(*WinCertificateAuthenticode)
 	c.Check(ok, Equals, true)
 
-	caBytes, err := ioutil.ReadFile("testdata/certs/canonical-uefi-ca.der")
+	caBytes, err := os.ReadFile("testdata/certs/canonical-uefi-ca.der")
 	c.Check(err, IsNil)
 	ca, err := x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
@@ -113,7 +112,7 @@ func (s *wincertSuite) TestWinCertificationAuthenticodeCertLikelyTrustAnchorWith
 	}
 	c.Check(authenticodeCert.CertLikelyTrustAnchor(ca), Equals, true)
 
-	caBytes, err = ioutil.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
+	caBytes, err = os.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
 	c.Check(err, IsNil)
 	ca, err = x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
@@ -143,14 +142,14 @@ func (s *wincertSuite) TestWinCertificationAuthenticodeSelfSigned(c *C) {
 	h.Write(authenticodeCert.GetSigner().RawTBSCertificate)
 	c.Check(h.Sum(nil), DeepEquals, DecodeHexString(c, "9f7950889a4a2195d9e3959123db19877617b95a3027ce8beef9b9c92fd4b438"))
 
-	caBytes, err := ioutil.ReadFile("testdata/certs/PkKek-1-snakeoil.der")
+	caBytes, err := os.ReadFile("testdata/certs/PkKek-1-snakeoil.der")
 	c.Check(err, IsNil)
 	ca, err := x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
 
 	c.Check(authenticodeCert.CertLikelyTrustAnchor(ca), Equals, true)
 
-	caBytes, err = ioutil.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
+	caBytes, err = os.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
 	c.Check(err, IsNil)
 	ca, err = x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
@@ -171,7 +170,7 @@ func (s *wincertSuite) TestWinCertificationAuthenticodeCertLikelyTrustAnchorWith
 	authenticodeCert, ok := cert.(*WinCertificateAuthenticode)
 	c.Check(ok, Equals, true)
 
-	caBytes, err := ioutil.ReadFile("testdata/certs/PkKek-1-snakeoil.der")
+	caBytes, err := os.ReadFile("testdata/certs/PkKek-1-snakeoil.der")
 	c.Check(err, IsNil)
 	ca, err := x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)
@@ -186,7 +185,7 @@ func (s *wincertSuite) TestWinCertificationAuthenticodeCertLikelyTrustAnchorWith
 	}
 	c.Check(authenticodeCert.CertLikelyTrustAnchor(ca), Equals, true)
 
-	caBytes, err = ioutil.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
+	caBytes, err = os.ReadFile("testdata/certs/MicCorKEKCA2011_2011-06-24.crt")
 	c.Check(err, IsNil)
 	ca, err = x509.ParseCertificate(caBytes)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Use `os.Read/WriteFile` and `io.ReadAll` instead of deprecated `ioutil` package.